### PR TITLE
Update DRSingleCrystal.xml. 

### DIFF
--- a/compact/DRSingleCrystal.xml
+++ b/compact/DRSingleCrystal.xml
@@ -271,7 +271,7 @@
     <property name="RINDEX"        ref="RINDEX__PbWO4"/>
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
       <property name="FASTCOMPONENT" ref="scintFast_PS"/>
-      <constant name="SCINTILLATIONYIELD" value="0.05/keV"/>
+      <constant name="SCINTILLATIONYIELD" value="0.10/keV"/>
       <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>
   </material>


### PR DESCRIPTION
Increased SCINTILLATIONYIELD to 0.10/keV (by a factor 2) to obtain the scintillation luminosity of ~200 photons/MeV as expected for PbWO4 crystals. See http://scintillator.lbl.gov/