### PR TITLE
make single dual Crystal a stand alone DD4hep Plugin Package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ dd4hep_configure_output ()
 dd4hep_add_plugin ( SingleDualCrystal
     GENERATED G__SingleDualCrystal.cxx 
   SOURCES src/*.cpp src/plugins/*.cpp
-  USES    DD4hep::DDCore DD4hep::DDAlign DD4hep::DDCond DD4hep::DDG4 DDDetectors
+  USES    DD4hep::DDCore DD4hep::DDAlign DD4hep::DDCond DD4hep::DDG4 
           ROOT::Core ROOT::Geom ROOT::GenVector CLHEP::CLHEP Geant4::Interface
 )
 
@@ -92,7 +92,7 @@ target_link_options(SingleDualCrystal PRIVATE -L${Geant4_DIR}/..)
 #
 #
 install(TARGETS SingleDualCrystal LIBRARY DESTINATION lib)
-install(DIRECTORY include/SingleDualCrystal DESTINATION include)
+#install(DIRECTORY include/SingleDualCrystal DESTINATION include)
 #
 #---Package installation procedure(s) -----------------------------------------
 install(DIRECTORY data eve scripts DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/SingleDualCrystal )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@
 #==========================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
+SET(PackageName SingleDualCrystal)
+
+PROJECT(${PackageName})
+
 IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
@@ -99,3 +103,4 @@ install(DIRECTORY data eve scripts DESTINATION ${CMAKE_INSTALL_PREFIX}/examples/
 #
 #
 #
+dd4hep_instantiate_package(${PackageName})

--- a/compact/SCEPCALcosmicSteering.py
+++ b/compact/SCEPCALcosmicSteering.py
@@ -264,9 +264,10 @@ def exampleUserPlugin(dd4hepSimulation):
          # Geant4InputAction is the type of plugin, Cry1 just an identifier
          gen = GeneratorAction(Kernel(), 'Geant4InputAction/Cry1' , True)
          # CRYEventReader is the actual plugin, steeringFile its constructor parameter
-         gen.Input = 'CRYEventReader|' + 'steeringFile'
+         steeringFile = "../DDCry/cry/test/setup.file"
+         gen.Input = 'CRYEventReader|' + steeringFile
          # we can give a dictionary of Parameters that has to be interpreted by the setParameters function of the plugin
-         gen.Parameters = {'DataFilePath': '../../../../DDCry/cry/data'}
+         gen.Parameters = {'DataFilePath': '../DDCry/cry/data'}
          gen.enableUI()
          return gen
 ## 


### PR DESCRIPTION
This makes it possible to compile SingleDualCrystal just by itself, without having to change DD4hep files.
e.g.
```
source /cvmfs/sft.cern.ch/lcg/views/LCG_102b/x86_64-centos7-gcc11-opt/setup.sh
git clone https://github.com/saraheno/SingleDualCrystal.git
cd  SingleDualCrustal
mkdir build
cd build
cmake -D CMAKE_INSTALL_PREFIX=$PWD/../install ..
make -j 4
make install
source ../install/bin/thisSingleDualCrystal.sh
source /cvmfs/sft.cern.ch/lcg/views/LCG_102b/x86_64-centos7-gcc11-opt/setup.sh
```
(There is a problem with DD4hep (thisDD4hep.sh dropping too many things from the LD_LIBRARY_PATH, so we have to source the LCG setup.sh at the end again).

Then you can run ddsim